### PR TITLE
Fix default DocumentDbStorageOptions

### DIFF
--- a/Hangfire.AzureDocumentDB/DocumentDbStorage.cs
+++ b/Hangfire.AzureDocumentDB/DocumentDbStorage.cs
@@ -107,7 +107,7 @@ namespace Hangfire.Azure
             logger.Info("Using the following options for Azure DocumentDB job storage:");
             logger.Info($"     DocumentDB Url: {Client.ServiceEndpoint.AbsoluteUri}");
             logger.Info($"     Request Timeout: {Options.RequestTimeout}");
-            logger.Info($"     Counter Agggerate Interval: {Options.CountersAggregateInterval.TotalSeconds} seconds");
+            logger.Info($"     Counter Aggregate Interval: {Options.CountersAggregateInterval.TotalSeconds} seconds");
             logger.Info($"     Queue Poll Interval: {Options.QueuePollInterval.TotalSeconds} seconds");
             logger.Info($"     Expiration Check Interval: {Options.ExpirationCheckInterval.TotalSeconds} seconds");
         }
@@ -116,7 +116,7 @@ namespace Hangfire.Azure
         /// Return the name of the database
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"DoucmentDb Database : {Options.DatabaseName}";
+        public override string ToString() => $"DocumentDb Database : {Options.DatabaseName}";
 
         private void Initialize()
         {
@@ -142,7 +142,7 @@ namespace Hangfire.Azure
                 string[] storedProcedureFiles = assembly.GetManifestResourceNames().Where(n => n.EndsWith(".js")).ToArray();
                 foreach (string storedProcedureFile in storedProcedureFiles)
                 {
-                    logger.Info($"Creating storedprocedure : {storedProcedureFile}");
+                    logger.Info($"Creating stored procedure : {storedProcedureFile}");
                     Stream stream = assembly.GetManifestResourceStream(storedProcedureFile);
                     using (MemoryStream memoryStream = new MemoryStream())
                     {

--- a/Hangfire.AzureDocumentDB/DocumentDbStorageOptions.cs
+++ b/Hangfire.AzureDocumentDB/DocumentDbStorageOptions.cs
@@ -13,18 +13,18 @@ namespace Hangfire.Azure
         internal string CollectionName { get; set; }
 
         /// <summary>
-        /// Get or sets the request timemout for DocumentDB client. Default value set to 30 seconds
+        /// Get or sets the request timeout for DocumentDB client. Default value set to 30 seconds
         /// </summary>
         public TimeSpan RequestTimeout { get; set; }
 
         /// <summary>
-        /// Get or set the interval timespan to process expired enteries. Default value 15 minutes
-        /// Expired items under "locks", "jobs", "lists", "sets", "hashs", "counters/aggregrated" will be checked 
+        /// Get or set the interval timespan to process expired entries. Default value 15 minutes
+        /// Expired items under "locks", "jobs", "lists", "sets", "hashs", "counters/aggregated" will be checked 
         /// </summary>
         public TimeSpan ExpirationCheckInterval { get; set; }
 
         /// <summary>
-        /// Get or sets the interval timespan to aggreated the counters. Default value 1 minute
+        /// Get or sets the interval timespan to aggregated the counters. Default value 1 minute
         /// </summary>
         public TimeSpan CountersAggregateInterval { get; set; }
 
@@ -39,9 +39,9 @@ namespace Hangfire.Azure
         public DocumentDbStorageOptions()
         {
             RequestTimeout = TimeSpan.FromSeconds(30);
-            ExpirationCheckInterval = TimeSpan.FromMinutes(2);
+            ExpirationCheckInterval = TimeSpan.FromMinutes(15);
             CountersAggregateInterval = TimeSpan.FromMinutes(1);
-            QueuePollInterval = TimeSpan.FromSeconds(2);
+            QueuePollInterval = TimeSpan.FromMinutes(2);
         }
     }
 }


### PR DESCRIPTION
- align default `DocumentDbStorageOptions` with documentation comments
- fix spelling in `DocumentDbStorage.ToString()`