### PR TITLE
Make DocumentDB Client ConnectionMode and Protocol configurable

### DIFF
--- a/Hangfire.AzureDocumentDB/DocumentDbStorage.cs
+++ b/Hangfire.AzureDocumentDB/DocumentDbStorage.cs
@@ -56,8 +56,8 @@ namespace Hangfire.Azure
             };
 
             ConnectionPolicy connectionPolicy = ConnectionPolicy.Default;
-            connectionPolicy.ConnectionMode = ConnectionMode.Direct;
-            connectionPolicy.ConnectionProtocol = Protocol.Tcp;
+            connectionPolicy.ConnectionMode = Options.ConnectionMode;
+            connectionPolicy.ConnectionProtocol = Options.ConnectionProtocol;
             connectionPolicy.RequestTimeout = Options.RequestTimeout;
             connectionPolicy.RetryOptions = new RetryOptions
             {

--- a/Hangfire.AzureDocumentDB/DocumentDbStorageOptions.cs
+++ b/Hangfire.AzureDocumentDB/DocumentDbStorageOptions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Azure.Documents.Client;
+using System;
 
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
@@ -34,6 +35,16 @@ namespace Hangfire.Azure
         public TimeSpan QueuePollInterval { get; set; }
 
         /// <summary>
+        /// Gets or sets the connection mode for the DocumentDB client. Default value is Direct.
+        /// </summary>
+        public ConnectionMode ConnectionMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connection protocol for the DocumentDB client. Default value is TCP.
+        /// </summary>
+        public Protocol ConnectionProtocol { get; set; }
+
+        /// <summary>
         /// Create an instance of AzureDocumentDB Storage option with default values
         /// </summary>
         public DocumentDbStorageOptions()
@@ -42,6 +53,8 @@ namespace Hangfire.Azure
             ExpirationCheckInterval = TimeSpan.FromMinutes(2);
             CountersAggregateInterval = TimeSpan.FromMinutes(1);
             QueuePollInterval = TimeSpan.FromSeconds(2);
+            ConnectionMode = ConnectionMode.Direct;
+            ConnectionProtocol = Protocol.Tcp;
         }
     }
 }


### PR DESCRIPTION
Due to https://github.com/Azure/azure-cosmosdb-dotnet/issues/194 there needs to be a possibility for the using app to change connection mode and/or protocol. Since there is already an options class, I simply added two properties to it and use the current hardcoded values as defaults. I believe this PR follows the code patterns that you have already established.