### PR TITLE
Set EnableCrossPartitionQuery=true

### DIFF
--- a/Hangfire.AzureDocumentDB/DocumentDbConnection.cs
+++ b/Hangfire.AzureDocumentDB/DocumentDbConnection.cs
@@ -214,7 +214,11 @@ namespace Hangfire.Azure
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
 
-            FeedOptions feedOptions = new FeedOptions { MaxItemCount = endingAt + 1 };
+            FeedOptions feedOptions = new FeedOptions { 
+              EnableCrossPartitionQuery = true,
+              MaxItemCount = endingAt + 1 
+            };
+
             endingAt += 1 - startingFrom;
 
             return Storage.Client.CreateDocumentQuery<Set>(Storage.CollectionUri, feedOptions)
@@ -486,7 +490,10 @@ namespace Hangfire.Azure
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
 
-            FeedOptions feedOptions = new FeedOptions { MaxItemCount = endingAt + 1 };
+            FeedOptions feedOptions = new FeedOptions { 
+              EnableCrossPartitionQuery = true,
+              MaxItemCount = endingAt + 1 
+            };
             endingAt += 1 - startingFrom;
 
             return Storage.Client.CreateDocumentQuery<List>(Storage.CollectionUri, feedOptions)

--- a/Hangfire.AzureDocumentDB/DocumentDbMonitoringApi.cs
+++ b/Hangfire.AzureDocumentDB/DocumentDbMonitoringApi.cs
@@ -119,6 +119,7 @@ namespace Hangfire.Azure
 
                     FeedOptions feedOptions = new FeedOptions
                     {
+                        EnableCrossPartitionQuery = true,
                         MaxItemCount = 1000,
                     };
 
@@ -290,7 +291,10 @@ namespace Hangfire.Azure
         private JobList<T> GetJobsOnState<T>(string stateName, int from, int count, Func<State, Common.Job, T> selector)
         {
             List<KeyValuePair<string, T>> jobs = new List<KeyValuePair<string, T>>();
-            FeedOptions feedOptions = new FeedOptions { MaxItemCount = from + count };
+            FeedOptions feedOptions = new FeedOptions { 
+              EnableCrossPartitionQuery = true,
+              MaxItemCount = from + count 
+            };
 
             List<Documents.Job> filterJobs = storage.Client.CreateDocumentQuery<Documents.Job>(storage.CollectionUri, feedOptions)
                  .Where(j => j.DocumentType == DocumentTypes.Job && j.StateName == stateName)
@@ -334,7 +338,10 @@ namespace Hangfire.Azure
                 }
             };
 
-            FeedOptions feedOptions = new FeedOptions { MaxItemCount = from + count };
+            FeedOptions feedOptions = new FeedOptions { 
+              EnableCrossPartitionQuery = true,
+              MaxItemCount = from + count 
+            };
 
             List<Documents.Queue> queues = storage.Client.CreateDocumentQuery<Documents.Queue>(storage.CollectionUri, sql, feedOptions)
                  .ToQueryResult()

--- a/Hangfire.AzureDocumentDB/Queue/JobQueueMonitoringApi.cs
+++ b/Hangfire.AzureDocumentDB/Queue/JobQueueMonitoringApi.cs
@@ -65,7 +65,10 @@ namespace Hangfire.Azure.Queue
 
         public IEnumerable<string> GetEnqueuedJobIds(string queue, int from, int perPage)
         {
-            FeedOptions feedOptions = new FeedOptions { MaxItemCount = from + perPage };
+            FeedOptions feedOptions = new FeedOptions { 
+                EnableCrossPartitionQuery = true,
+                MaxItemCount = from + perPage 
+            };
 
             return storage.Client.CreateDocumentQuery<Documents.Queue>(storage.CollectionUri, feedOptions)
                 .Where(q => q.DocumentType == DocumentTypes.Queue && q.Name == queue && q.FetchedAt.IsDefined() == false)
@@ -77,7 +80,10 @@ namespace Hangfire.Azure.Queue
 
         public IEnumerable<string> GetFetchedJobIds(string queue, int from, int perPage)
         {
-            FeedOptions feedOptions = new FeedOptions { MaxItemCount = from + perPage };
+            FeedOptions feedOptions = new FeedOptions { 
+                EnableCrossPartitionQuery = true,
+                MaxItemCount = from + perPage 
+            };
 
             return storage.Client.CreateDocumentQuery<Documents.Queue>(storage.CollectionUri, feedOptions)
                 .Where(q => q.DocumentType == DocumentTypes.Queue && q.Name == queue && q.FetchedAt.IsDefined())


### PR DESCRIPTION
When I was trying use show the Hangfire Dashboard in Azure I just got an HTTP 500.
After inspecting the logs I spottet the following error:
```
2019-02-08 13:57:05.580 +00:00 [Error] Microsoft.AspNetCore.Server.IIS.Core.IISHttpServer: Connection ID "16285016254182338617", Request ID "8000303a-0000-e200-b63f-84710c7967bb": An unhandled exception was thrown by the application.
System.AggregateException: One or more errors occurred. (Cross partition query is required but disabled. Please set x-ms-documentdb-query-enablecrosspartition to true, specify x-ms-documentdb-partitionkey, or revise your query to avoid this exception.
ActivityId: bd03d759-62a9-4a4d-994e-430ae178ea6e, Microsoft.Azure.Documents.Common/2.1.0.0, Windows/10.0.14393 documentdb-netcore-sdk/2.2.0) ---> Microsoft.Azure.Documents.DocumentClientException: Cross partition query is required but disabled. Please set x-ms-documentdb-query-enablecrosspartition to true, specify x-ms-documentdb-partitionkey, or revise your query to avoid this exception.
ActivityId: bd03d759-62a9-4a4d-994e-430ae178ea6e, Microsoft.Azure.Documents.Common/2.1.0.0, Windows/10.0.14393 documentdb-netcore-sdk/2.2.0
   at Microsoft.Azure.Documents.Client.ClientExtensions.ParseResponseAsync(HttpResponseMessage responseMessage, JsonSerializerSettings serializerSettings, Boolean throwOnKnownClientErrorCodes)
   at Microsoft.Azure.Documents.GatewayStoreModel.<>c__DisplayClass21_0.<<InvokeAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.<>c__DisplayClass1_0.<<ExecuteAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.ShouldRetryResult.ThrowIfDoneTrying(ExceptionDispatchInfo capturedException)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteAsync(Func`1 callbackMethod, IRetryPolicy retryPolicy, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.GatewayStoreModel.InvokeAsync(DocumentServiceRequest request, ResourceType resourceType, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.GatewayStoreModel.ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Client.DocumentClient.ExecuteQueryAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryClient.ExecuteQueryAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteQueryRequestInternalAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteQueryRequestAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteRequestAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DefaultDocumentQueryExecutionContext.ExecuteOnceAsync(IDocumentClientRetryPolicy retryPolicyInstance, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DefaultDocumentQueryExecutionContext.<>c__DisplayClass9_0.<<ExecuteInternalAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.<>c__DisplayClass1_0.<<ExecuteAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.ShouldRetryResult.ThrowIfDoneTrying(ExceptionDispatchInfo capturedException)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteAsync(Func`1 callbackMethod, IRetryPolicy retryPolicy, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.Query.DefaultDocumentQueryExecutionContext.ExecuteInternalAsync(CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteNextAsync(CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.ProxyDocumentQueryExecutionContext.ExecuteNextAsync(CancellationToken token)
   at Microsoft.Azure.Documents.Linq.DocumentQuery`1.ExecuteNextPrivateAsync[TResponse](CancellationToken cancellationToken)
   at Hangfire.Azure.Helper.ClientHelper.ExecuteNextWithRetriesAsync[T](IDocumentQuery`1 query)
   at Hangfire.Azure.Helper.QueryHelper.<>c__DisplayClass0_0`1.<<ToQueryResult>b__0>d.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at Hangfire.Azure.Helper.QueryHelper.ToQueryResult[T](IQueryable`1 source)
   at Hangfire.Azure.DocumentDbMonitoringApi.GetStatistics()
   at Hangfire.Dashboard.RazorPage.<Assign>b__52_0()
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at Hangfire.Dashboard.RazorPage.get_Statistics()
   at Hangfire.Dashboard.DashboardMetrics.<>c.<.cctor>b__1_0(RazorPage page)
   at Hangfire.Dashboard.JsonStats.Dispatch(DashboardContext context)
   at Hangfire.Dashboard.AspNetCoreDashboardMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.Invoke(HttpContext httpContext)
   at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync()
---> (Inner Exception #0) Microsoft.Azure.Documents.DocumentClientException: Cross partition query is required but disabled. Please set x-ms-documentdb-query-enablecrosspartition to true, specify x-ms-documentdb-partitionkey, or revise your query to avoid this exception.
ActivityId: bd03d759-62a9-4a4d-994e-430ae178ea6e, Microsoft.Azure.Documents.Common/2.1.0.0, Windows/10.0.14393 documentdb-netcore-sdk/2.2.0
   at Microsoft.Azure.Documents.Client.ClientExtensions.ParseResponseAsync(HttpResponseMessage responseMessage, JsonSerializerSettings serializerSettings, Boolean throwOnKnownClientErrorCodes)
   at Microsoft.Azure.Documents.GatewayStoreModel.<>c__DisplayClass21_0.<<InvokeAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.<>c__DisplayClass1_0.<<ExecuteAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.ShouldRetryResult.ThrowIfDoneTrying(ExceptionDispatchInfo capturedException)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteAsync(Func`1 callbackMethod, IRetryPolicy retryPolicy, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.GatewayStoreModel.InvokeAsync(DocumentServiceRequest request, ResourceType resourceType, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.GatewayStoreModel.ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Client.DocumentClient.ExecuteQueryAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryClient.ExecuteQueryAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteQueryRequestInternalAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteQueryRequestAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteRequestAsync(DocumentServiceRequest request, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DefaultDocumentQueryExecutionContext.ExecuteOnceAsync(IDocumentClientRetryPolicy retryPolicyInstance, CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DefaultDocumentQueryExecutionContext.<>c__DisplayClass9_0.<<ExecuteInternalAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.<>c__DisplayClass1_0.<<ExecuteAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.ShouldRetryResult.ThrowIfDoneTrying(ExceptionDispatchInfo capturedException)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteAsync(Func`1 callbackMethod, IRetryPolicy retryPolicy, CancellationToken cancellationToken, Action`1 preRetryCallback)
   at Microsoft.Azure.Documents.Query.DefaultDocumentQueryExecutionContext.ExecuteInternalAsync(CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.DocumentQueryExecutionContextBase.ExecuteNextAsync(CancellationToken cancellationToken)
   at Microsoft.Azure.Documents.Query.ProxyDocumentQueryExecutionContext.ExecuteNextAsync(CancellationToken token)
   at Microsoft.Azure.Documents.Linq.DocumentQuery`1.ExecuteNextPrivateAsync[TResponse](CancellationToken cancellationToken)
   at Hangfire.Azure.Helper.ClientHelper.ExecuteNextWithRetriesAsync[T](IDocumentQuery`1 query)
   at Hangfire.Azure.Helper.QueryHelper.<>c__DisplayClass0_0`1.<<ToQueryResult>b__0>d.MoveNext()<---
```

The code had been working fine locally using the Azure Storage Emulator.

After some research I stumbled over the `EnableCrossPartitionQuery` option. Setting this option `true` resolved my issue while using Azure as DocumentDB host.

Although I didn't explicitly set any partition keys on the collection I guess Azure sets it internally (I also cannot find any partition option in the collections settings).